### PR TITLE
Fetch the latest video from YouTube automatically.

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,7 +22,8 @@ title: Home
         <figure class="image is-16by9">
         <script src="{{ "/js/yt.js" | prepend: site.baseurl }}"></script>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
-        <iframe class="has-ratio" id="youtube_video" frameborder="0"></iframe>    
+        <iframe class="has-ratio" id="youtube_video" frameborder="0"></iframe>   
+        <noscript>To view this video, please enable JavaScript!</p></noscript>  
         </figure>
         <br />
         <a href="https://youtube.com/BobPony/videos" class="button is-primary is-rounded">View more videos</a>

--- a/index.html
+++ b/index.html
@@ -23,7 +23,7 @@ title: Home
         <script src="{{ "/js/yt.js" | prepend: site.baseurl }}"></script>
         <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
         <iframe class="has-ratio" id="youtube_video" frameborder="0"></iframe>   
-        <noscript>To view this video, please enable JavaScript!</p></noscript>  
+        <noscript>To view this video, please enable JavaScript!</noscript>  
         </figure>
         <br />
         <a href="https://youtube.com/BobPony/videos" class="button is-primary is-rounded">View more videos</a>

--- a/index.html
+++ b/index.html
@@ -20,11 +20,13 @@ title: Home
       <div class="box has-text-centered">
         <h2 class="title is-4">Watch one of the newest videos</h2>
         <figure class="image is-16by9">
-        <iframe class="has-ratio" src="https://www.youtube-nocookie.com/embed/3PS1sErFL4s?modestbranding=1&disablekb=1&cc_load_policy=1" frameborder="0"></iframe>      
+        <script src="{{ "/js/yt.js" | prepend: site.baseurl }}"></script>
+        <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.7.1/jquery.min.js"></script>
+        <iframe class="has-ratio" id="youtube_video" frameborder="0"></iframe>    
         </figure>
         <br />
         <a href="https://youtube.com/BobPony/videos" class="button is-primary is-rounded">View more videos</a>
-              <a href="https://youtube.com/BobPony" class="button is-danger is-rounded">Subscribe</a>
+              <a href="https://youtube.com/BobPony?sub_confirmation=1" class="button is-danger is-rounded">Subscribe</a>
       </div>
       <div class="box smallbox">
         <div class="columns">

--- a/js/yt.js
+++ b/js/yt.js
@@ -1,0 +1,11 @@
+document.addEventListener('DOMContentLoaded', () => {
+
+  // Fetch the latest video on Bob's channel to later embed it. Uses the method found at https://stackoverflow.com/a/45342740.
+  var channelID = "UCAZzz2Dd9Xh6vTjNcxhqPZw";
+  var reqURL = "https://www.youtube.com/feeds/videos.xml?channel_id=";
+  $.getJSON("https://api.rss2json.com/v1/api.json?rss_url=" + encodeURIComponent(reqURL) + channelID, function(data) {
+    var link = data.items[0].link;
+    var id = link.substr(link.indexOf("=") + 1);
+    $("#youtube_video").attr("src", "https://youtube.com/embed/" + id + "?rel=0&disablekb=1&cc_load_policy=1");
+  });
+});

--- a/js/yt.js
+++ b/js/yt.js
@@ -6,6 +6,6 @@ document.addEventListener('DOMContentLoaded', () => {
   $.getJSON("https://api.rss2json.com/v1/api.json?rss_url=" + encodeURIComponent(reqURL) + channelID, function(data) {
     var link = data.items[0].link;
     var id = link.substr(link.indexOf("=") + 1);
-    $("#youtube_video").attr("src", "https://youtube-nocookie.com/embed/" + id + "?rel=0&disablekb=1&cc_load_policy=1");
+    $("#youtube_video").attr("src", "https://www.youtube-nocookie.com/embed/" + id + "?rel=0&disablekb=1&cc_load_policy=1");
   });
 });

--- a/js/yt.js
+++ b/js/yt.js
@@ -6,6 +6,6 @@ document.addEventListener('DOMContentLoaded', () => {
   $.getJSON("https://api.rss2json.com/v1/api.json?rss_url=" + encodeURIComponent(reqURL) + channelID, function(data) {
     var link = data.items[0].link;
     var id = link.substr(link.indexOf("=") + 1);
-    $("#youtube_video").attr("src", "https://youtube.com/embed/" + id + "?rel=0&disablekb=1&cc_load_policy=1");
+    $("#youtube_video").attr("src", "https://youtube-nocookie.com/embed/" + id + "?rel=0&disablekb=1&cc_load_policy=1");
   });
 });


### PR DESCRIPTION
This PR allows the latest video from your channel to be pulled and shown, without hardcoding it every single time. It works by utilizing some code from stackoverflow, and the appropriate answer has been linked in a comment to comply with the Creative Commons license. Additionally, the "Subscribe" button has been changed to automatically prompt the user to subscribe without any manual intervention. Since modestbranding has been deprecated into doing nothing, it has been removed to prevent breakages in the future. I have also added the "rel" flag to only show related videos from your channel, which could help attract newcomers into looking more into your channel. Previously, these were all random and all came from different channels, hurting integration with the site.