### PR TITLE
Add new links and icons for Meta Threads and Bluesky.

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -47,7 +47,7 @@
         <a rel="me" href="https://mastodon.social/@bobpony" class="navbar-item" title="Mastodon">
           <i class="fab fa-mastodon"></i>
         </a>
-		<a rel="me" href="https://bsky.app/profile/bobpony.com" class="navbar-item" title="Bluesky">
+        <a rel="me" href="https://bsky.app/profile/bobpony.com" class="navbar-item" title="Bluesky">
           <i class="fas fa-cloud"></i>
         </a>
         <a rel="me" href="https://www.threads.net/@thebobpony" class="navbar-item" title="Threads">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -56,7 +56,7 @@
         <a rel="me" href="/discord" class="navbar-item" title="Discord Server">
           <i class="fab fa-discord"></i>
         </a>
-		<a href="https://github.com/TheBobPony/bobpony.com" class="navbar-item" title="GitHub">
+        <a href="https://github.com/TheBobPony/bobpony.com" class="navbar-item" title="GitHub">
           <i class="fab fa-github"></i>
         </a>
         <a href="/contact" class="navbar-item {% if page.url == "/contact/" %}is-active{% endif %}" title="Contact">

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -47,6 +47,12 @@
         <a rel="me" href="https://mastodon.social/@bobpony" class="navbar-item" title="Mastodon">
           <i class="fab fa-mastodon"></i>
         </a>
+		<a rel="me" href="https://bsky.app/profile/bobpony.com" class="navbar-item" title="Bluesky">
+          <i class="fas fa-cloud"></i>
+        </a>
+        <a rel="me" href="https://www.threads.net/@thebobpony" class="navbar-item" title="Threads">
+          <i class="fab fa-threads"></i>
+        </a>
         <a rel="me" href="/discord" class="navbar-item" title="Discord Server">
           <i class="fab fa-discord"></i>
         </a>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -4,7 +4,7 @@
 <head>
   <!-- Resources -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bulma@0.9.4/css/bulma.min.css">
-  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css" integrity="sha512-MV7K8+y+gLIBoVD59lQIYicR65iaqukzvf/nwasF0nqhPay5w/9lJmVM2hMDcnK1OnMGCdVK+iQrJ7lzPJQd1w==" crossorigin="anonymous" referrerpolicy="no-referrer" />  {% include head.html %}
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css" integrity="sha512-DTOQO9RWCH3ppGqcWaEA1BIZOC6xxalwEsw9c2QQeAIftl+Vegovlnee1c9QX4TctnWMn13TZye+giMm8e2LwA==" crossorigin="anonymous" referrerpolicy="no-referrer" />  {% include head.html %}
   <script src="{{ "/js/nav.js" | prepend: site.baseurl }}"></script>
   <title>{% if page.title %}{{ page.title }} - Bob Pony{% else %}Bob Pony{% endif %}</title>
 </head>


### PR DESCRIPTION
This PR upgrades FontAwesome to 6.5.1 to allow usage of the Meta Threads icon. As there's no icon for Bluesky currently in a released build of FontAwesome, a generic substitute, a cloud, is used. This also fixes what seems to be a spacing inconsistency.