### PR TITLE
Add a status button. Remove the defunct Video Archive button.

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -27,12 +27,12 @@
             <span>Downloads</span>
           </span>
         </a>
-		<a href="https://video.bobpony.com" class="navbar-item">
+		<a href="https://status.bobpony.com/" class="navbar-item">
           <span class="icon-text">
             <span class="icon">
-              <i class="fas fa-video"></i>
+              <i class="fas fa-arrow-trend-up"></i>
             </span>
-            <span>Video Archive</span>
+            <span>Status</span>
           </span>
         </a>
       </div>


### PR DESCRIPTION
This PR does what the title says, removes the defunct Video Archive button, and replaces it with a button that leads to status.bobpony.com. Here's what the site looks like after this change.
![image](https://github.com/TheBobPony/bobpony.com/assets/96768305/2163cd20-c3ec-4ff9-a690-53a38595cd61)
