### PR TITLE
Workaround a CSS issue in older versions of Chrome.

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,7 +1,7 @@
 <nav class="navbar is-info is-fixed-top" role="navigation" aria-label="main navigation">
   <div class="container" id="container">
     <div class="navbar-brand">
-        <img class="navlogo" width="50" height="50" src="/img/favicon.png">
+        <img class="navlogo" style="width:50px;height:52px;" src="/img/favicon.png">
       <a role="button" class="navbar-burger" aria-label="menu" aria-expanded="false" data-target="navbarBasicExample">
         <span aria-hidden="true"></span>
         <span aria-hidden="true"></span>


### PR DESCRIPTION
In older versions of Chrome (61, 73, etc) the navbar is broken and stretched.

<img width="960" alt="Screenshot 2024-03-18 011526" src="https://github.com/TheBobPony/bobpony.com/assets/96768305/908e1bd8-d579-4ed9-a6fb-f16f7ff7772c">

Fixing this is possible by simply overriding the CSS.

<img width="960" alt="Screenshot 2024-03-18 011545" src="https://github.com/TheBobPony/bobpony.com/assets/96768305/ee330fd4-02b9-4278-a730-8cbb90d0438c">