### PR TITLE
Fix older versions of Firefox and K-Meleon

### DIFF
--- a/downloads/index.html
+++ b/downloads/index.html
@@ -70,4 +70,5 @@ layout: default
                 </div>
         </div>
     <!-- Script tags here! -->
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=Element.prototype.append"></script>
     <script src="./listing.js"></script>

--- a/downloads/listing.js
+++ b/downloads/listing.js
@@ -7,6 +7,7 @@ const downloadURL = document.querySelector("#download");
 
 fetch("./products.json").then(data => data.json().then(products => {
 	productList = products;
+        // Normally we'd use constants, but Firefox <51 doesn't work right with the way we use them, so use variables.
 	for (var i in products) {
 		typeObj.append(new Option(i, i));
 	}
@@ -14,13 +15,13 @@ fetch("./products.json").then(data => data.json().then(products => {
 
 const updateVersions = () => {
 	const versionOptions = document.querySelectorAll("#version option");
-
+        // ditto
 	for (var i of versionOptions) {
 		if (!i.disabled) i.remove();
 	}
 
 	document.querySelector("#version option[value='placeholder']").selected = true;
-
+        // ditto
 	for (var i in productList[typeObj.value]) {
 		versionObj.append(new Option(i, i));
 	}

--- a/downloads/listing.js
+++ b/downloads/listing.js
@@ -7,7 +7,7 @@ const downloadURL = document.querySelector("#download");
 
 fetch("./products.json").then(data => data.json().then(products => {
 	productList = products;
-	for (const i in products) {
+	for (var i in products) {
 		typeObj.append(new Option(i, i));
 	}
 }));
@@ -15,13 +15,13 @@ fetch("./products.json").then(data => data.json().then(products => {
 const updateVersions = () => {
 	const versionOptions = document.querySelectorAll("#version option");
 
-	for (const i of versionOptions) {
+	for (var i of versionOptions) {
 		if (!i.disabled) i.remove();
 	}
 
 	document.querySelector("#version option[value='placeholder']").selected = true;
 
-	for (const i in productList[typeObj.value]) {
+	for (var i in productList[typeObj.value]) {
 		versionObj.append(new Option(i, i));
 	}
 


### PR DESCRIPTION
Older Firefox versions (K-Meleon included) throw a SyntaxError when constants are used in a for of loop.


![image](https://github.com/TheBobPony/bobpony.com/assets/96768305/f16c8722-3acd-43ba-a891-6d10776b586e)
![image](https://github.com/TheBobPony/bobpony.com/assets/96768305/d2035f15-b983-47be-be42-1f6e2cf3ef48)

To workaround this, use variables instead. Additionally, polyfill append for some 4x releases.

![image](https://github.com/TheBobPony/bobpony.com/assets/96768305/4c4979fc-650a-4fdb-a7dd-65a85d5d2f26)

