### PR TITLE
Fix URL formatting for Windows Vista 6.0.5840

### DIFF
--- a/downloads/products.json
+++ b/downloads/products.json
@@ -671,7 +671,7 @@
             "6.0.5536 x86": "https://dl.bobpony.com/windows/beta/longhorn/x86/6.0.5536.16385.vista_rc1.060821-1900_x86fre_client-business-homebasic-homepremium-ultimate-homebasicn-businessn-starter_retail_en-us-LR1CFRE_EN_DVD.7z",
             "6.0.5600 x86": "https://dl.bobpony.com/windows/beta/longhorn/x86/6.0.5600.16384.vista_rc1.060829-2230_x86fre_client-multisku_retail_en-us.7z",
             "6.0.5744 x86": "https://dl.bobpony.com/windows/beta/longhorn/x86/6.0.5744.16384.vista_rtm_edw.061003-1945_x86fre_client-multisku_retail_en-us.7z",
-            "6.0.5840 x86": "https://dl.bobpony.com/windows/beta/longhorn/x86/6.0.5840.16384.vista_rtm.061018-1900_x86fre_client-business-homebasic-homepremium-ultimate-homebasicn-businessn-starter_retail_en-us-UDF%20VOLUME.7z,"
+            "6.0.5840 x86": "https://dl.bobpony.com/windows/beta/longhorn/x86/6.0.5840.16384.vista_rtm.061018-1900_x86fre_client-business-homebasic-homepremium-ultimate-homebasicn-businessn-starter_retail_en-us-UDF%20VOLUME.7z"
         },
         "Windows 7": {
             "6.1.6469.1 x86": "https://dl.bobpony.com/windows/beta/7/x86/6.1.6469.1.fbl_find_dev%28wexbuild%29.071002-1531_x86fre_client-unstaged_retail_en-us.7z",


### PR DESCRIPTION
For some reason, an extra comma was added here that completely breaks the download. Fix that.